### PR TITLE
Wire secp256k1 C backend

### DIFF
--- a/Shared/WalletCoreProxy/Secp256k1Backend/big_wallet_secp256k1_shim.c
+++ b/Shared/WalletCoreProxy/Secp256k1Backend/big_wallet_secp256k1_shim.c
@@ -1,0 +1,199 @@
+// ∅ 2026 lil org
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include "secp256k1/include/secp256k1.h"
+#include "secp256k1/include/secp256k1_recovery.h"
+
+static secp256k1_context *bw_secp256k1_context = NULL;
+static pthread_once_t bw_secp256k1_context_once = PTHREAD_ONCE_INIT;
+
+static void bw_secp256k1_noop_callback(const char *message, void *data) {
+    (void)message;
+    (void)data;
+}
+
+static void bw_secp256k1_init_context(void) {
+    unsigned char seed[32];
+    bw_secp256k1_context = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+    if (bw_secp256k1_context == NULL) {
+        abort();
+    }
+    secp256k1_context_set_illegal_callback(bw_secp256k1_context, bw_secp256k1_noop_callback, NULL);
+    arc4random_buf(seed, sizeof(seed));
+    if (!secp256k1_context_randomize(bw_secp256k1_context, seed)) {
+        memset(seed, 0, sizeof(seed));
+        abort();
+    }
+    memset(seed, 0, sizeof(seed));
+}
+
+static const secp256k1_context *bw_secp256k1_get_context(void) {
+    pthread_once(&bw_secp256k1_context_once, bw_secp256k1_init_context);
+    return bw_secp256k1_context;
+}
+
+int32_t bw_secp256k1_is_valid_private_key(const uint8_t *private_key32) {
+    if (private_key32 == NULL) {
+        return 0;
+    }
+    return secp256k1_ec_seckey_verify(bw_secp256k1_get_context(), private_key32);
+}
+
+int32_t bw_secp256k1_create_public_key(const uint8_t *private_key32,
+                                       uint8_t *public_key_out,
+                                       size_t *public_key_len,
+                                       int32_t compressed) {
+    secp256k1_pubkey public_key;
+    unsigned int flags = compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+    if (private_key32 == NULL || public_key_out == NULL || public_key_len == NULL) {
+        return 0;
+    }
+    if (!secp256k1_ec_pubkey_create(bw_secp256k1_get_context(), &public_key, private_key32)) {
+        return 0;
+    }
+    *public_key_len = compressed ? 33 : 65;
+    return secp256k1_ec_pubkey_serialize(bw_secp256k1_get_context(),
+                                          public_key_out,
+                                          public_key_len,
+                                          &public_key,
+                                          flags);
+}
+
+int32_t bw_secp256k1_is_valid_public_key(const uint8_t *public_key,
+                                         size_t public_key_len) {
+    secp256k1_pubkey parsed;
+    if (public_key == NULL) {
+        return 0;
+    }
+    return secp256k1_ec_pubkey_parse(bw_secp256k1_get_context(), &parsed, public_key, public_key_len);
+}
+
+int32_t bw_secp256k1_serialize_public_key(const uint8_t *public_key,
+                                          size_t public_key_len,
+                                          uint8_t *public_key_out,
+                                          size_t *public_key_out_len,
+                                          int32_t compressed) {
+    secp256k1_pubkey parsed;
+    unsigned int flags = compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+    if (public_key == NULL || public_key_out == NULL || public_key_out_len == NULL) {
+        return 0;
+    }
+    if (!secp256k1_ec_pubkey_parse(bw_secp256k1_get_context(), &parsed, public_key, public_key_len)) {
+        return 0;
+    }
+    *public_key_out_len = compressed ? 33 : 65;
+    return secp256k1_ec_pubkey_serialize(bw_secp256k1_get_context(),
+                                          public_key_out,
+                                          public_key_out_len,
+                                          &parsed,
+                                          flags);
+}
+
+int32_t bw_secp256k1_sign_recoverable(const uint8_t *digest32,
+                                      const uint8_t *private_key32,
+                                      uint8_t *signature65_out) {
+    secp256k1_ecdsa_recoverable_signature signature;
+    int recovery_id = 0;
+    if (digest32 == NULL || private_key32 == NULL || signature65_out == NULL) {
+        return 0;
+    }
+    if (!secp256k1_ecdsa_sign_recoverable(bw_secp256k1_get_context(),
+                                           &signature,
+                                           digest32,
+                                           private_key32,
+                                           NULL,
+                                           NULL)) {
+        return 0;
+    }
+    if (!secp256k1_ecdsa_recoverable_signature_serialize_compact(bw_secp256k1_get_context(),
+                                                                  signature65_out,
+                                                                  &recovery_id,
+                                                                  &signature)) {
+        return 0;
+    }
+    signature65_out[64] = (uint8_t)recovery_id;
+    return 1;
+}
+
+int32_t bw_secp256k1_recover_public_key(const uint8_t *digest32,
+                                        const uint8_t *signature65,
+                                        uint8_t *public_key65_out) {
+    secp256k1_ecdsa_recoverable_signature signature;
+    secp256k1_pubkey public_key;
+    size_t public_key_len = 65;
+    int recovery_id;
+    if (digest32 == NULL || signature65 == NULL || public_key65_out == NULL) {
+        return 0;
+    }
+    recovery_id = signature65[64];
+    if (recovery_id >= 27) {
+        recovery_id -= 27;
+    }
+    if (recovery_id < 0 || recovery_id > 3) {
+        return 0;
+    }
+    if (!secp256k1_ecdsa_recoverable_signature_parse_compact(bw_secp256k1_get_context(),
+                                                              &signature,
+                                                              signature65,
+                                                              recovery_id)) {
+        return 0;
+    }
+    if (!secp256k1_ecdsa_recover(bw_secp256k1_get_context(), &public_key, &signature, digest32)) {
+        return 0;
+    }
+    return secp256k1_ec_pubkey_serialize(bw_secp256k1_get_context(),
+                                          public_key65_out,
+                                          &public_key_len,
+                                          &public_key,
+                                          SECP256K1_EC_UNCOMPRESSED);
+}
+
+int32_t bw_secp256k1_combine_public_keys(const uint8_t *left_public_key,
+                                         size_t left_public_key_len,
+                                         const uint8_t *right_public_key,
+                                         size_t right_public_key_len,
+                                         uint8_t *public_key65_out) {
+    secp256k1_pubkey left;
+    secp256k1_pubkey right;
+    secp256k1_pubkey combined;
+    const secp256k1_pubkey *public_keys[2];
+    size_t public_key_len = 65;
+    if (left_public_key == NULL || right_public_key == NULL || public_key65_out == NULL) {
+        return 0;
+    }
+    if (!secp256k1_ec_pubkey_parse(bw_secp256k1_get_context(), &left, left_public_key, left_public_key_len)) {
+        return 0;
+    }
+    if (!secp256k1_ec_pubkey_parse(bw_secp256k1_get_context(), &right, right_public_key, right_public_key_len)) {
+        return 0;
+    }
+    public_keys[0] = &left;
+    public_keys[1] = &right;
+    if (!secp256k1_ec_pubkey_combine(bw_secp256k1_get_context(), &combined, public_keys, 2)) {
+        return 0;
+    }
+    return secp256k1_ec_pubkey_serialize(bw_secp256k1_get_context(),
+                                          public_key65_out,
+                                          &public_key_len,
+                                          &combined,
+                                          SECP256K1_EC_UNCOMPRESSED);
+}
+
+int32_t bw_secp256k1_tweak_add_private_key(const uint8_t *private_key32,
+                                           const uint8_t *tweak32,
+                                           uint8_t *private_key32_out) {
+    if (private_key32 == NULL || tweak32 == NULL || private_key32_out == NULL) {
+        return 0;
+    }
+    memcpy(private_key32_out, private_key32, 32);
+    if (!secp256k1_ec_seckey_tweak_add(bw_secp256k1_get_context(), private_key32_out, tweak32)) {
+        memset(private_key32_out, 0, 32);
+        return 0;
+    }
+    return 1;
+}

--- a/Wallet.xcodeproj/project.pbxproj
+++ b/Wallet.xcodeproj/project.pbxproj
@@ -487,6 +487,22 @@
 		2F4C00032FA8000000000000 /* WalletCoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4C00002FA8000000000000 /* WalletCoreProxy.swift */; };
 		2F4C00042FA8000000000000 /* WalletCoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4C00002FA8000000000000 /* WalletCoreProxy.swift */; };
 		2F4C00052FA8000000000000 /* WalletCoreProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4C00002FA8000000000000 /* WalletCoreProxy.swift */; };
+		2F4D00722FAA000000000000 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00702FAA000000000000 /* secp256k1.c */; settings = {COMPILER_FLAGS = "-DENABLE_MODULE_RECOVERY=1 -Wno-unused-function"; }; };
+		2F4D00732FAA000000000000 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00702FAA000000000000 /* secp256k1.c */; settings = {COMPILER_FLAGS = "-DENABLE_MODULE_RECOVERY=1 -Wno-unused-function"; }; };
+		2F4D00742FAA000000000000 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00702FAA000000000000 /* secp256k1.c */; settings = {COMPILER_FLAGS = "-DENABLE_MODULE_RECOVERY=1 -Wno-unused-function"; }; };
+		2F4D00752FAA000000000000 /* secp256k1.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00702FAA000000000000 /* secp256k1.c */; settings = {COMPILER_FLAGS = "-DENABLE_MODULE_RECOVERY=1 -Wno-unused-function"; }; };
+		2F4D00762FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00712FAA000000000000 /* big_wallet_secp256k1_shim.c */; };
+		2F4D00772FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00712FAA000000000000 /* big_wallet_secp256k1_shim.c */; };
+		2F4D00782FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00712FAA000000000000 /* big_wallet_secp256k1_shim.c */; };
+		2F4D00792FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D00712FAA000000000000 /* big_wallet_secp256k1_shim.c */; };
+		2F4D007C2FAA000000000000 /* precomputed_ecmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007A2FAA000000000000 /* precomputed_ecmult.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		2F4D007D2FAA000000000000 /* precomputed_ecmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007A2FAA000000000000 /* precomputed_ecmult.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		2F4D007E2FAA000000000000 /* precomputed_ecmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007A2FAA000000000000 /* precomputed_ecmult.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		2F4D007F2FAA000000000000 /* precomputed_ecmult.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007A2FAA000000000000 /* precomputed_ecmult.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		2F4D00802FAA000000000000 /* precomputed_ecmult_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007B2FAA000000000000 /* precomputed_ecmult_gen.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		2F4D00812FAA000000000000 /* precomputed_ecmult_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007B2FAA000000000000 /* precomputed_ecmult_gen.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		2F4D00822FAA000000000000 /* precomputed_ecmult_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007B2FAA000000000000 /* precomputed_ecmult_gen.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		2F4D00832FAA000000000000 /* precomputed_ecmult_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4D007B2FAA000000000000 /* precomputed_ecmult_gen.c */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
 		2F4C00112FA8000000000000 /* WalletCoreProxyParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4C00102FA8000000000000 /* WalletCoreProxyParityTests.swift */; };
 		2F4C00122FA8000000000000 /* WalletCoreProxyParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4C00102FA8000000000000 /* WalletCoreProxyParityTests.swift */; };
 		2F4C00132FA8000000000000 /* WalletCoreProxyParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4C00102FA8000000000000 /* WalletCoreProxyParityTests.swift */; };
@@ -1180,6 +1196,10 @@
 		2F2A00000000000000000019 /* WalletsManagerPrivateKeyImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletsManagerPrivateKeyImportTests.swift; sourceTree = "<group>"; };
 		2F2A0000000000000000001D /* WalletsManagerPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletsManagerPreviewTests.swift; sourceTree = "<group>"; };
 		2F4C00002FA8000000000000 /* WalletCoreProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCoreProxy.swift; sourceTree = "<group>"; };
+		2F4D00702FAA000000000000 /* secp256k1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = Secp256k1Backend/secp256k1/src/secp256k1.c; sourceTree = "<group>"; };
+		2F4D00712FAA000000000000 /* big_wallet_secp256k1_shim.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = Secp256k1Backend/big_wallet_secp256k1_shim.c; sourceTree = "<group>"; };
+		2F4D007A2FAA000000000000 /* precomputed_ecmult.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = Secp256k1Backend/secp256k1/src/precomputed_ecmult.c; sourceTree = "<group>"; };
+		2F4D007B2FAA000000000000 /* precomputed_ecmult_gen.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = Secp256k1Backend/secp256k1/src/precomputed_ecmult_gen.c; sourceTree = "<group>"; };
 		2F4C00102FA8000000000000 /* WalletCoreProxyParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCoreProxyParityTests.swift; sourceTree = "<group>"; };
 		2F4C00142FA9000000000000 /* WalletCoreProxyTestVectors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCoreProxyTestVectors.swift; sourceTree = "<group>"; };
 		2F5E10002FA5000000F0000 /* RemoteImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageLoader.swift; sourceTree = "<group>"; };
@@ -2612,6 +2632,10 @@
 			isa = PBXGroup;
 			children = (
 				2F4C00002FA8000000000000 /* WalletCoreProxy.swift */,
+				2F4D00702FAA000000000000 /* secp256k1.c */,
+				2F4D007A2FAA000000000000 /* precomputed_ecmult.c */,
+				2F4D007B2FAA000000000000 /* precomputed_ecmult_gen.c */,
+				2F4D00712FAA000000000000 /* big_wallet_secp256k1_shim.c */,
 			);
 			path = WalletCoreProxy;
 			sourceTree = "<group>";
@@ -3297,6 +3321,10 @@
 				2C773FFD2D53C1C800879A1F /* Account.swift in Sources */,
 				2C773FFE2D53C1C800879A1F /* WalletsManager.swift in Sources */,
 				2F4C00042FA8000000000000 /* WalletCoreProxy.swift in Sources */,
+				2F4D00742FAA000000000000 /* secp256k1.c in Sources */,
+				2F4D007E2FAA000000000000 /* precomputed_ecmult.c in Sources */,
+				2F4D00822FAA000000000000 /* precomputed_ecmult_gen.c in Sources */,
+				2F4D00782FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */,
 				2CF9B1112D526F9900B5CE82 /* String.swift in Sources */,
 				2C773FC92D53A5A300879A1F /* MultipleResponseToExtension.swift in Sources */,
 				2C77401B2D53CBEC00879A1F /* AccountTableViewCell.swift in Sources */,
@@ -3343,6 +3371,10 @@
 				2C901C4A2689F01700D0926A /* Strings.swift in Sources */,
 				2C2AA1D228AD1DC100E35DBF /* SpecificWalletAccount.swift in Sources */,
 				2F4C00022FA8000000000000 /* WalletCoreProxy.swift in Sources */,
+				2F4D00722FAA000000000000 /* secp256k1.c in Sources */,
+				2F4D007C2FAA000000000000 /* precomputed_ecmult.c in Sources */,
+				2F4D00802FAA000000000000 /* precomputed_ecmult_gen.c in Sources */,
+				2F4D00762FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */,
 				2C6706A5267A6BFE006AAEF2 /* Bundle.swift in Sources */,
 				2C9B2C6D2D38416800D56607 /* SharedDefaults.swift in Sources */,
 				2CC0CDBE2692027E0072922A /* PriceService.swift in Sources */,
@@ -3500,6 +3532,10 @@
 				2C5FF97426C84F7B00B32ACC /* SceneDelegate.swift in Sources */,
 				2CF2559E275A479800AE54B9 /* WalletsManager.swift in Sources */,
 				2F4C00032FA8000000000000 /* WalletCoreProxy.swift in Sources */,
+				2F4D00732FAA000000000000 /* secp256k1.c in Sources */,
+				2F4D007D2FAA000000000000 /* precomputed_ecmult.c in Sources */,
+				2F4D00812FAA000000000000 /* precomputed_ecmult_gen.c in Sources */,
+				2F4D00772FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */,
 				2C90E62327B2ED2D00C8991E /* SafariRequest+Helpers.swift in Sources */,
 				2CC79DF92AFD4BD6002B5A2D /* TransactionInspector.swift in Sources */,
 				2C2AA1D628AFB1AD00E35DBF /* MultipleResponseToExtension.swift in Sources */,
@@ -3636,6 +3672,10 @@
 				2CE5BC415A831696EE25E651 /* MultipleResponseToExtension.swift in Sources */,
 				2CAE21DEE08852ED5A87648D /* DappRequestProcessor.swift in Sources */,
 				2F4C00052FA8000000000000 /* WalletCoreProxy.swift in Sources */,
+				2F4D00752FAA000000000000 /* secp256k1.c in Sources */,
+				2F4D007F2FAA000000000000 /* precomputed_ecmult.c in Sources */,
+				2F4D00832FAA000000000000 /* precomputed_ecmult_gen.c in Sources */,
+				2F4D00792FAA000000000000 /* big_wallet_secp256k1_shim.c in Sources */,
 				2CF2676F1861169B92F690A4 /* Transaction.swift in Sources */,
 				2C60964FCD7D7729CC2F5390 /* SafariRequest+Helpers.swift in Sources */,
 				2CD179BB4ADFB6932786B2B0 /* PlatformSpecificImage.swift in Sources */,


### PR DESCRIPTION
## Summary
- add `big_wallet_secp256k1_shim.c`
- wire only the C translation units into the Xcode project: `secp256k1.c`, `precomputed_ecmult.c`, `precomputed_ecmult_gen.c`, and the shim
- keep `WalletCoreProxy.swift` backed by WalletCore; no Swift replacement files are added here

## Verification
- `plutil -lint Wallet.xcodeproj/project.pbxproj`
- `xcodebuild -list -project Wallet.xcodeproj`
- standalone C compilation with `clang -Wall -Wextra -Werror -Wno-unused-function -DENABLE_MODULE_RECOVERY=1` for upstream secp256k1 units and `clang -Wall -Wextra -Werror` for the shim
- confirmed no replacement Swift files or macOS deployment target bump are present

## Stack note
This PR is stacked on #162 so the diff shows only compile wiring. After #162 merges, this branch can be retargeted to `main` or rebased onto updated `main` unchanged.

## Baseline note
Clean `origin/main` currently fails because `WalletCore` cannot be resolved. Per follow-up direction, this PR proceeds with slice-specific verification only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the `secp256k1` C backend into the Xcode project and added a small C shim for key, sign, and recover operations. This enables direct `secp256k1` calls while keeping the existing `WalletCore` proxy unchanged.

- **Refactors**
  - Added `big_wallet_secp256k1_shim.c` exposing helpers (key validation, pubkey create/serialize, recoverable sign/recover, combine, tweak).
  - Linked upstream `secp256k1` C units (`secp256k1.c`, `precomputed_ecmult.c`, `precomputed_ecmult_gen.c`) with `-DENABLE_MODULE_RECOVERY=1` and `-Wno-unused-function`.
  - No Swift replacements; `WalletCoreProxy.swift` remains backed by `WalletCore`.

<sup>Written for commit 538f6e00e4c2e610ef3a2c5094a823048818971f. Summary will update on new commits. <a href="https://cubic.dev/pr/lil-org/big-wallet/pull/163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

