### PR TITLE
Add BigUInt byte conversion helpers

### DIFF
--- a/Shared/Utilities/BigUInt.swift
+++ b/Shared/Utilities/BigUInt.swift
@@ -2,6 +2,27 @@
 
 import Foundation
 
+enum BigEndianWordData {
+    static func encode(_ words: [UInt32], minLength: Int = 0) -> Data {
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(max(minLength, words.count * 4))
+
+        for word in words.reversed() {
+            bytes.append(UInt8((word >> 24) & 0xff))
+            bytes.append(UInt8((word >> 16) & 0xff))
+            bytes.append(UInt8((word >> 8) & 0xff))
+            bytes.append(UInt8(word & 0xff))
+        }
+
+        let leadingZeroCount = bytes.firstIndex { $0 != 0 } ?? bytes.count
+        bytes.removeFirst(leadingZeroCount)
+        if bytes.count < minLength {
+            bytes.insert(contentsOf: Array(repeating: 0, count: minLength - bytes.count), at: 0)
+        }
+        return Data(bytes)
+    }
+}
+
 struct BigUInt: Equatable, Hashable, Comparable, Sendable, ExpressibleByIntegerLiteral, CustomStringConvertible {
 
     typealias IntegerLiteralType = UInt64
@@ -21,6 +42,15 @@ struct BigUInt: Equatable, Hashable, Comparable, Sendable, ExpressibleByIntegerL
         let low = UInt32(truncatingIfNeeded: value)
         let high = UInt32(value >> 32)
         words = high == 0 ? (low == 0 ? [] : [low]) : [low, high]
+    }
+
+    init(data: Data) {
+        self.init()
+
+        for byte in data {
+            multiply(bySmall: 256)
+            add(small: UInt32(byte))
+        }
     }
 
     init?(decimalString text: String) {
@@ -88,6 +118,10 @@ struct BigUInt: Equatable, Hashable, Comparable, Sendable, ExpressibleByIntegerL
             return String(repeating: "0", count: 8 - part.count) + part
         }.joined()
         return prefix + String(mostSignificant, radix: 16) + rest
+    }
+
+    func toData(minLength: Int = 0) -> Data {
+        return BigEndianWordData.encode(words, minLength: minLength)
     }
 
     func eth(shortest: Bool = false) -> String {

--- a/Tests/BigUIntTests.swift
+++ b/Tests/BigUIntTests.swift
@@ -40,6 +40,14 @@ final class BigUIntTests: XCTestCase {
         XCTAssertNil(BigUInt(decimalString: "12349A"))
     }
 
+    func testBigEndianDataRoundTrip() {
+        XCTAssertEqual(BigUInt(data: Data()).description, "0")
+        XCTAssertEqual(BigUInt(data: Data([0, 0, 1])).hexString, "1")
+        XCTAssertEqual(BigUInt(data: Data([0x12, 0x34, 0xab, 0xcd])).toData(), Data([0x12, 0x34, 0xab, 0xcd]))
+        XCTAssertEqual(BigUInt(1).toData(minLength: 4), Data([0, 0, 0, 1]))
+        XCTAssertEqual(BigUInt().toData(minLength: 2), Data([0, 0]))
+    }
+
     func testMultiplication() {
         let sample = BigUInt(hexString: "123456789abcdef")!
         XCTAssertEqual((BigUInt() * sample).description, "0")


### PR DESCRIPTION
## Summary
- add big-endian `Data` initialization for `BigUInt`
- add big-endian `Data` encoding with minimum-length padding
- add focused round-trip tests for empty, leading-zero, normal, and padded values

## Verification
- `git diff --cached --check` before commit
- `xcrun swiftc -typecheck Shared/Extensions/String.swift Shared/Utilities/BigUInt.swift`
- confirmed the incremental diff contains only `Shared/Utilities/BigUInt.swift` and `Tests/BigUIntTests.swift`

## Stack note
This PR is stacked on #163 so the diff shows only the BigUInt utility slice. After #162 and #163 merge, this branch can be retargeted to `main` or rebased onto updated `main` unchanged.

## Baseline note
Clean `origin/main` currently fails because `WalletCore` cannot be resolved. Per follow-up direction, this PR proceeds with slice-specific verification only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds big-endian Data↔BigUInt conversion to improve interoperability with wire protocols and ensure consistent zero-padding. Provides `init(data:)` and `toData(minLength:)`, plus round-trip tests for edge cases.

- **New Features**
  - `init(data:)` parses big-endian bytes.
  - `toData(minLength:)` encodes big-endian bytes with optional left zero-padding.
  - Round-trip tests for empty, leading-zero, normal, and padded values.

<sup>Written for commit c6e8236a23e6cd7b9b0ae98441232eb0d9894af4. Summary will update on new commits. <a href="https://cubic.dev/pr/lil-org/big-wallet/pull/164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

