### PR TITLE
fix: upgrade jwt to ~> 2.10.3, >= 3.2.0 (CVE-2026-45363)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem 'jwt', '2.10.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     httpclient (2.8.3)
     jmespath (1.6.2)
     json (2.7.2)
-    jwt (2.8.1)
+    jwt (2.10.3)
       base64
     mini_magick (4.12.0)
     mini_mime (1.1.5)
@@ -213,6 +213,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
+  jwt (= 2.10.3)
 
 BUNDLED WITH
    2.5.4


### PR DESCRIPTION
## Summary
Upgrade jwt from 2.8.1 to ~> 2.10.3, >= 3.2.0 to fix CVE-2026-45363.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-45363 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-45363` |
| **File** | `Gemfile.lock` |
| **Assessment** | Likely exploitable |

**Description**: ruby-jwt: Empty-key HMAC bypass; cross-language sibling of CVE-2026-44351

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-45363` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `Gemfile`
- `Gemfile.lock`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `jwt` from 2.8.1 to 2.10.3 to fix CVE-2026-45363 (empty-key HMAC bypass). This removes a high-severity risk in token validation.

<sup>Written for commit 73fbee361baa7186055c4f1548a8ea984c6dd093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lil-org/big-wallet/pull/166?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

